### PR TITLE
Try parsing CSV w/o sniffing if it fails after sniffing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Try to parse CSV w/o sniffing (excel dialect) before sniffing if it fails
+- Try to parse CSV w/o sniffing (excel dialect) after sniffing if it fails
 
 ## 0.0.7 (2018-09-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current (in progress)
 
-- Nothing yet
+- Try to parse CSV w/o sniffing (excel dialect) before sniffing if it fails
 
 ## 0.0.7 (2018-09-17)
 

--- a/csvapi/parser.py
+++ b/csvapi/parser.py
@@ -20,7 +20,7 @@ def detect_encoding(filepath):
 
 
 def from_csv(filepath, encoding='utf-8', sniff_limit=SNIFF_LIMIT):
-    """Try first w/o sniffing and then sniff if it fails"""
+    """Try first w/ sniffing and then w/o sniffing if it fails"""
     try:
         return agate.Table.from_csv(filepath, sniff_limit=sniff_limit, encoding=encoding)
     except ValueError:

--- a/csvapi/parser.py
+++ b/csvapi/parser.py
@@ -20,7 +20,11 @@ def detect_encoding(filepath):
 
 
 def from_csv(filepath, encoding='utf-8', sniff_limit=SNIFF_LIMIT):
-    return agate.Table.from_csv(filepath, sniff_limit=sniff_limit, encoding=encoding)
+    """Try first w/o sniffing and then sniff if it fails"""
+    try:
+        return agate.Table.from_csv(filepath, encoding=encoding)
+    except ValueError:
+        return agate.Table.from_csv(filepath, sniff_limit=sniff_limit, encoding=encoding)
 
 
 def from_excel(filepath):

--- a/csvapi/parser.py
+++ b/csvapi/parser.py
@@ -22,9 +22,9 @@ def detect_encoding(filepath):
 def from_csv(filepath, encoding='utf-8', sniff_limit=SNIFF_LIMIT):
     """Try first w/o sniffing and then sniff if it fails"""
     try:
-        return agate.Table.from_csv(filepath, encoding=encoding)
-    except ValueError:
         return agate.Table.from_csv(filepath, sniff_limit=sniff_limit, encoding=encoding)
+    except ValueError:
+        return agate.Table.from_csv(filepath, encoding=encoding)
 
 
 def from_excel(filepath):


### PR DESCRIPTION
WIP: Try parsing CSV w/o sniffing if it fails after sniffing.

It's equivalent to falling back on the default dialect, just in case.

Fix parsing of https://gist.githubusercontent.com/abulte/31b992ef353d6d72510cab6d956960e0/raw/7f79fca63dbe4036c88116ea64423288004cc9bd/export-reutilisation-mai-septembre-2018.csv